### PR TITLE
Adding the testing project to the Solution and fixing the WumpusCore csproj

### DIFF
--- a/Core/WumpusCore/WumpusCore.csproj
+++ b/Core/WumpusCore/WumpusCore.csproj
@@ -53,7 +53,6 @@
         <Compile Include="Trivia\Questions.cs" />
         <Compile Include="Trivia\Trivia.cs" />
         <Compile Include="HighScore\HighScore.cs" />
-        <Compile Include="HighScore\StoredHighScore.cs" />
         <Compile Include="GameLocations\GameLocations.cs" />
     </ItemGroup>
     <ItemGroup>

--- a/Core/WumpusCore/WumpusCore.sln
+++ b/Core/WumpusCore/WumpusCore.sln
@@ -1,6 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34018.315
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WumpusCore", "WumpusCore.csproj", "{20024C3F-3BAA-43EA-81CD-BD1137931B9B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Testing", "..\Testing\Testing.csproj", "{5AF91DA1-E949-47DD-9242-B29C82C025FB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,5 +17,12 @@ Global
 		{20024C3F-3BAA-43EA-81CD-BD1137931B9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20024C3F-3BAA-43EA-81CD-BD1137931B9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20024C3F-3BAA-43EA-81CD-BD1137931B9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AF91DA1-E949-47DD-9242-B29C82C025FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AF91DA1-E949-47DD-9242-B29C82C025FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AF91DA1-E949-47DD-9242-B29C82C025FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AF91DA1-E949-47DD-9242-B29C82C025FB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
* I completely forgot to add the Testing project as a project on the solution, so that's been done.
* The "StoredHighScore" file was still on the compile list in the csproj despite being removed a LONG time ago.